### PR TITLE
Fix build errors with gcc 13

### DIFF
--- a/socks5.hpp
+++ b/socks5.hpp
@@ -153,7 +153,7 @@ namespace socks5 {
                 ipv4_octets              ipv4;
                 ipv6_octets              ipv6;
                 std::array<uint8_t, 256> domain{0}; // length prefixed
-            } payload;
+            } payload = {0};
 
             size_t var_length() const {
                 return sizeof(type) + payload_length();
@@ -182,7 +182,7 @@ namespace socks5 {
             // constructors
             request_t(Endpoint const& ep) : port(ep.port())
             {
-                auto& addr = ep.address();
+                auto&& addr = ep.address();
                 if (addr.is_v4()) {
                     var_address.type         = addr_type::IPv4;
                     var_address.payload.ipv4 = addr.to_v4().to_bytes();

--- a/socks5.hpp
+++ b/socks5.hpp
@@ -30,7 +30,7 @@ namespace socks5 { // threw in the kitchen sink for error codes
         failed = 99,
     };
 
-    auto const& get_result_category() {
+    inline auto const& get_result_category() {
       struct impl : error_category {
         const char* name() const noexcept override { return "result_code"; }
         std::string message(int ev) const override {
@@ -65,7 +65,7 @@ namespace socks5 { // threw in the kitchen sink for error codes
       return instance;
     }
 
-    error_code make_error_code(result_code se) {
+    inline error_code make_error_code(result_code se) {
         return error_code{
             static_cast<std::underlying_type<result_code>::type>(se),
             get_result_category()};


### PR DESCRIPTION
I am trying to use socks5.hpp in my [project](/bvcxza/sonos) and I got these build error/warning with gcc 13:

```
- Warning
asio-socks45-client/socks5.hpp:220:26: error: missing initializer for member 'socks5::core_t<boost::asio::ip::tcp>::wire_address::payload' [-Werror=missing-field-initializers]
  220 |             wire_address var_address {addr_type::IPv4};
      |                          ^~~~~~~~~~~

- Error
asio-socks45-client/socks5.hpp:185:23: error: cannot bind non-const lvalue reference of type 'boost::asio::ip::address&' to an rvalue of type 'boost::asio::ip::address'
  185 |                 auto& addr = ep.address();
      |                       ^~~~
```

This PR fix them.